### PR TITLE
feat(css): add mobile responsive breakpoints for hero, about, and nav

### DIFF
--- a/static/css/about.css
+++ b/static/css/about.css
@@ -209,4 +209,55 @@
 }
 
 
+/* =================================
+   MOBILE RESPONSIVE
+   ================================= */
+
+@media (max-width: 900px) {
+  /* Full-bleed section margin adjustment */
+  .looking-for-section {
+    margin-left: -24px;
+    margin-right: -24px;
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  /* Hide decorative section numbers */
+  .drives-path-section::before,
+  .quote-image-beyond-module::before,
+  .looking-for-section::before {
+    display: none;
+  }
+
+  /* Hide vertical metadata text */
+  .drives-path-section .grid-row::after {
+    display: none;
+  }
+
+  /* Reduce tall hero image height */
+  .image-wrapper-hero {
+    height: 400px;
+  }
+
+  /* Quote section breathing room */
+  .quote-image-beyond-module {
+    padding: var(--space-3xl) 0;
+  }
+
+  /* CTA footer - stack and reorder */
+  .cta-footer-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .cta-footer-grid .contact-sentence {
+    order: 1;
+  }
+
+  .cta-footer-grid .cta-button-wrapper {
+    order: 2;
+  }
+}
+
 /* --- END OF ABOUT PAGE STYLES --- */

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -138,3 +138,33 @@ h1.hero-main-visual-text .line-2 {
   background: rgba(43, 43, 43, 0.05);
   border-bottom-color: rgba(43, 43, 43, 0.5);
 }
+
+/* =================================
+   MOBILE RESPONSIVE
+   ================================= */
+
+@media (max-width: 900px) {
+  .hero-section-wrapper {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    max-height: none;
+    padding: var(--space-xl) var(--space-lg);
+    margin-bottom: var(--space-3xl);
+    transform: none;
+  }
+
+  .hero-left-column {
+    height: 280px;
+    min-height: unset;
+    margin: 0;
+  }
+
+  .hero-right-column {
+    padding: var(--space-xl) 0 0 0;
+    transform: none;
+  }
+
+  .hero-content::before {
+    display: none;
+  }
+}

--- a/static/css/nav.css
+++ b/static/css/nav.css
@@ -211,10 +211,16 @@ nav ul li a[aria-current="page"] {
   .nav-inner {
     flex-wrap: wrap;
     padding: 0 var(--space-lg);
+    align-items: center;
   }
 
   .nav-left-group {
     flex: 1;
+    align-items: center;
+  }
+
+  .burger-menu-label {
+    align-items: center;
   }
 
   .nav-right-group {


### PR DESCRIPTION
- Stack homepage hero to single column on mobile (900px breakpoint)
- Adjust about page full-bleed margins and hide decorative elements
- Reorder CTA footer on mobile (contact sentence first, download last)
- Center burger menu vertically in nav bar