### PR TITLE
fix(nav): make mobile menu links stretch full width

### DIFF
--- a/static/css/nav.css
+++ b/static/css/nav.css
@@ -211,6 +211,7 @@ nav ul li a:hover {
     box-shadow: 0 8px 16px rgba(28, 28, 28, 0.06);
     display: none;
     flex-direction: column;
+    align-items: stretch;
     padding: var(--space-lg) 0;
   }
 


### PR DESCRIPTION
Override align-items: baseline (inherited from desktop styles) with stretch so navigation links span the entire screen width on mobile.